### PR TITLE
Fixed typo in readme code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ import {
 const PostHandlerTypes = { 
   ...HandlerTypes, 
   addComment: 'addComment', 
-  editComment: 'editComment
+  editComment: 'editComment'
 }
 
 const post = createObjReducer({


### PR DESCRIPTION
Before:

<img width="909" alt="screen shot 2018-11-03 at 10 27 33 pm" src="https://user-images.githubusercontent.com/6138182/47959997-c3b18380-dfb7-11e8-8fa4-006a6ed1ea17.png">

After:

<img width="906" alt="screen shot 2018-11-03 at 10 27 19 pm" src="https://user-images.githubusercontent.com/6138182/47959998-c9a76480-dfb7-11e8-8f72-0f335c6899ec.png">
